### PR TITLE
Add possible candidate for touch event detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,52 +1,60 @@
 # CHANGELOG
 
+## 7.0.0
+
+* Update build process to use a single module, reducing size a bit in
+  the process
+* Change the way touch detection occurs such that it waits for a valid
+  touch event on the window. Removed the `hasTouch` property, which
+  shouldn't be necessary (we can add it back if we get requests).
+
 ## 6.3.0
 
-- Replace legacy string refs
-- Allow className to be overriden
+* Replace legacy string refs
+* Allow className to be overriden
 
 ## 6.2.0
 
-- Remove PropTypes and createClass usage to prevent deprecation
+* Remove PropTypes and createClass usage to prevent deprecation
   warnings with React 15.5.x
 
 ## 6.1.1
 
-- Fix case where ink would hang when switching windows. [Thanks @hhaidar](https://github.com/vigetlabs/react-ink/pull/30)
+* Fix case where ink would hang when switching windows. [Thanks @hhaidar](https://github.com/vigetlabs/react-ink/pull/30)
 
 ## v6.1.0
 
-- Add TypeScript definitions
+* Add TypeScript definitions
 
 ## v6.0.1
 
-- Removed some dependencies that should not have been included in production
+* Removed some dependencies that should not have been included in production
 
 ## v6.0.0
 
-- Remove React as a peer dependency
-- Remove onTouchLeave event, which is no longer supported
-- Upgrade Babel to Babel 6
+* Remove React as a peer dependency
+* Remove onTouchLeave event, which is no longer supported
+* Upgrade Babel to Babel 6
 
 ## v5.1.1
 
-- Use inline source-map to avoid warnings with including external map.
+* Use inline source-map to avoid warnings with including external map.
 
 ## v5.1.0
 
-- Moved babel compilation configuration from package.json into webpack
+* Moved babel compilation configuration from package.json into webpack
   config to avoid cross-project babel compilation issues
 
 ## v5.0.2
 
-- Lower minimum peerDependency to 0.12. Turns it that we can support
+* Lower minimum peerDependency to 0.12. Turns it that we can support
   it.
 
 ## v5.0.1
 
-- Fix case in React 0.13.3 where DOM node could not be found
+* Fix case in React 0.13.3 where DOM node could not be found
 
 ## v5.0.0
 
-- Updates to internals to support React 0.14.0
-- Breaking peer dependency update to React 0.13.0
+* Updates to internals to support React 0.14.0
+* Breaking peer dependency update to React 0.13.0

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,11 @@
  */
 
 import React from 'react'
-import { HAS_TOUCH } from './util/hasTouch'
 import { pixelRatio } from './util/pixelRatio'
 import { STYLE } from './style'
 import { Store } from './util/store'
 import { merge } from './util/merge'
+import { touchMonitor } from './util/touch-monitor'
 import {
   getBlotScale,
   getBlotOpacity,
@@ -27,23 +27,21 @@ const defaultProps = {
   duration: 1000,
   opacity: 0.25,
   radius: 150,
-  recenter: true,
-  hasTouch: HAS_TOUCH
+  recenter: true
 }
 
 export default class Ink extends React.PureComponent {
   constructor(props) {
-    super(...arguments)
+    super(props)
 
     this.state = {
       color: 'transparent',
       density: 1,
       height: 0,
       store: Store(this.tick.bind(this)),
-      width: 0
+      width: 0,
+      hasTouch: false
     }
-
-    this.touchEvents = this.touchEvents()
   }
 
   touchEvents() {
@@ -103,7 +101,12 @@ export default class Ink extends React.PureComponent {
     ctx.fill()
   }
 
+  componentDidMount() {
+    this.ignoreTouch = touchMonitor(() => this.setState({ hasTouch: true }))
+  }
+
   componentWillUnmount() {
+    this.ignoreTouch()
     this.state.store.stop()
   }
 
@@ -153,7 +156,7 @@ export default class Ink extends React.PureComponent {
         onDragOver: this._onRelease,
         style: merge(STYLE, style)
       },
-      this.touchEvents
+      this.touchEvents()
     )
 
     return React.createElement('canvas', props)

--- a/src/util/touch-monitor.js
+++ b/src/util/touch-monitor.js
@@ -1,0 +1,47 @@
+/**
+ * Check for touch event support by picking up the first actual touch
+ * on the window Listen for an actual touch event on the window. This
+ * appears to be the only consistent way to check for touch.
+ */
+
+let listening = false
+let hasTouch = false
+let callbacks = []
+let noop = () => {}
+
+function didTouch() {
+  hasTouch = true
+
+  for (var i = 0; i < callbacks.length; i++) {
+    callbacks[i]()
+    callbacks = null
+  }
+
+  window.removeEventListener('touchstart', didTouch, true)
+}
+
+function init() {
+  if (!listening) {
+    listening = true
+    window.addEventListener('touchstart', didTouch, true)
+  }
+}
+
+function ignore(callback) {
+  let index = callbacks.indexOf(callback)
+
+  if (index >= 0) {
+    callbacks.splice(index, 1)
+  }
+}
+
+export function touchMonitor(callback) {
+  if (hasTouch) {
+    callback()
+    return noop
+  } else {
+    init()
+    callbacks.push(callback)
+    return ignore.bind(null, callback)
+  }
+}


### PR DESCRIPTION
This commit updates the way we do touch detection such that it waits
for the first valid touch event before assuming touch is supported. It
looks like Chrome and Firefox think that Touch is supported otherwise.