### PR TITLE
Adjusted radius props to assume higher values than width or height pa…

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -8,7 +8,7 @@ class Component extends React.Component {
     return (
       <div>
         <h1>Click anywhere!</h1>
-        <Ink ref="background" />
+        <Ink ref="background" radius={150} />
         <button style={{ position: 'relative' }} onClick={toggle}>
           Toggle Stress Test
           <Ink key="__ink" />

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,6 @@ const defaultProps = {
   className: 'ink',
   duration: 1000,
   opacity: 0.25,
-  radius: 150,
   recenter: true,
   hasTouch: HAS_TOUCH
 }

--- a/src/util/equations.js
+++ b/src/util/equations.js
@@ -22,7 +22,7 @@ function getRadius(blot) {
 }
 
 export function getMaxRadius(height, width, radius) {
-  return min(max(height, width) * 0.5, radius)
+  return radius || min(max(height, width) * 0.6)
 }
 
 export function getBlotOpacity(blot, opacity) {
@@ -37,11 +37,11 @@ export function getBlotOuterOpacity(blot, opacity) {
 }
 
 export function getBlotShiftX(blot, size, width) {
-  return min(1, getRadius(blot) / size * 2 / SQRT_2) * (width / 2 - blot.x)
+  return min(1, ((getRadius(blot) / size) * 2) / SQRT_2) * (width / 2 - blot.x)
 }
 
 export function getBlotShiftY(blot, size, height) {
-  return min(1, getRadius(blot) / size * 2 / SQRT_2) * (height / 2 - blot.y)
+  return min(1, ((getRadius(blot) / size) * 2) / SQRT_2) * (height / 2 - blot.y)
 }
 
 export function getBlotScale(blot) {


### PR DESCRIPTION
I think more convenient to let `radius` assume by itself the max value between width and height of the parent element instead randomly 150 (what does it mean?).

In case of user want to force a radius value, so radius assume the user prop `radius`.

Checking out all material design concepts, I didn't find anything about default ripple value (specially in buttons) but we can see ripple effect reaching all button borders. It means getting the higher value between width and height and applying a division by two for `radius`.

[Material Design Button](https://material.io/components/buttons/)

