### PR TITLE
Read className from props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -141,8 +141,8 @@ export default class Ink extends React.PureComponent {
   }
 
   render() {
-    let { className, density, height, width } = this.state
-    let { style } = this.props
+    let { density, height, width } = this.state
+    let { className, style } = this.props
 
     let props = merge(
       {


### PR DESCRIPTION
It's currently pulling `className` from state, but it's only defined in props.