### PR TITLE
Fix _onRelease binding in onDragOver handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /**
  * Ink
- * Fills a container with an SVG object that provides feedback on mouse/touch
+ * Fills a container with a canvas object that provides feedback on mouse/touch
  * events with a rippling pool.
  */
 
@@ -149,7 +149,7 @@ export default class Ink extends React.PureComponent {
         ref: this.setCanvas.bind(this),
         height: height * density,
         width: width * density,
-        onDragOver: this._onRelease,
+        onDragOver: this._onRelease.bind(this),
         style: merge(STYLE, style)
       },
       this.touchEvents


### PR DESCRIPTION
Easy way to trigger an error is to add `draggable` attribute to the button in `example` and try to drag it. There will be a bunch of "Uncaught TypeError: Cannot read properties of undefined (reading 'state')" errors in the console

![Screenshot from 2022-05-11 16-17-27](https://user-images.githubusercontent.com/64609/167861624-96254415-204a-4cad-b105-276c15d63462.png)
