### PR TITLE
Prevent Ink from altering the accessibility tree

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,6 +145,7 @@ export default class Ink extends React.PureComponent {
 
     let props = merge(
       {
+        'aria-hidden': true,
         className: className,
         ref: this.setCanvas.bind(this),
         height: height * density,


### PR DESCRIPTION
When rendered inside a `<button>`, canvas element produces an unintended side-effect in Chrome, changing the announced role of the button to "button, group". Adding `aria-hidden="true"` effectively hides the canvas element from assistive software such as screen readers, so the role of the button is correctly announced as just "button".