### PR TITLE
Fix render react 18+

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -135,28 +135,26 @@ export default class Ink extends React.PureComponent {
     })
   }
 
-  setCanvas(el) {
+  setCanvas = (el) => {
     this.canvas = el
   }
 
   render() {
     let { density, height, width } = this.state
     let { className, style } = this.props
-
-    let props = merge(
-      {
-        'aria-hidden': true,
-        className: className,
-        ref: this.setCanvas.bind(this),
-        height: height * density,
-        width: width * density,
-        onDragOver: this._onRelease.bind(this),
-        style: merge(STYLE, style)
-      },
-      this.touchEvents
-    )
-
-    return React.createElement('canvas', props)
+  
+    let props = {
+      'aria-hidden': true,
+      className: className,
+      ref: this.setCanvas.bind(this),
+      height: height * density,
+      width: width * density,
+      onDragOver: this._onRelease.bind(this),
+      style: merge(STYLE, style),
+      ...this.touchEvents
+    }
+  
+    return <canvas {...props} />
   }
 
   _onPress(event) {


### PR DESCRIPTION
solution to the render error, which previously gave the invalid JSX error

```
'Ink' cannot be used as a JSX component.
  Its instance type 'Ink' is not a valid JSX element.
    The types returned by 'render()' are incompatible between these types.
      Type 'React.ReactNode' is not assignable to type 'import("**/node_modules/@types/react-dom/node_modules/@types/react/index").ReactNode'.
        Type 'PromiseLikeOfReactNode' is not assignable to type 'ReactNode'.
```
